### PR TITLE
Fix critical bugs in apply_subpixel_distortion and apply_subpixel_geometry_distortion

### DIFF
--- a/lensfunpy/_lensfun.pyx
+++ b/lensfunpy/_lensfun.pyx
@@ -949,10 +949,10 @@ cdef class Modifier:
         
         :return: per-channel coordinates for subpixel distortion correction,
                  or None if calibration data missing
-        :rtype: ndarray of shape (height, width, 2, 3) or None
+        :rtype: ndarray of shape (height, width, 3, 2) or None
         """
         width, height = self._widthHeight(width, height)
-        cdef np.ndarray[DTYPE_t, ndim=4, mode='c'] res = np.empty((height, width, 2, 3), dtype=DTYPE)
+        cdef np.ndarray[DTYPE_t, ndim=4, mode='c'] res = np.empty((height, width, 3, 2), dtype=DTYPE)
         if lf_modifier_apply_subpixel_distortion(self.lf, xu, yu, width, height, &res[0,0,0,0]):
             return res
         else:
@@ -963,10 +963,10 @@ cdef class Modifier:
         
         :return: per-channel coordinates for combined distortion and subpixel distortion correction,
                  or None if calibration data missing
-        :rtype: ndarray of shape (height, width, 2, 3) or None
+        :rtype: ndarray of shape (height, width, 3, 2) or None
         """
         width, height = self._widthHeight(width, height)
-        cdef np.ndarray[DTYPE_t, ndim=4, mode='c'] res = np.empty((height, width, 2, 3), dtype=DTYPE)
+        cdef np.ndarray[DTYPE_t, ndim=4, mode='c'] res = np.empty((height, width, 3, 2), dtype=DTYPE)
         if lf_modifier_apply_subpixel_geometry_distortion(self.lf, xu, yu, width, height, &res[0,0,0,0]):
             return res
         else:


### PR DESCRIPTION
The arrays returned from Lensfun are ordered as Height x Width x Channels x (x,y) coordinates, not  Height x Width x (x,y) coordinates x Channels.

See official code for correct usage: https://lensfun.github.io/manual/latest/lenstool_8cpp-example.html

no need to swapaxes on green channel anymore as in #17 
