### PR TITLE
Update dependencies for Windows build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def windows_lensfun_compile():
     cmake = os.path.abspath('external/cmake-{}-win32-x86/bin/cmake.exe'.format(cmake_version))
 
     # Download vcpkg to build dependencies of lensfun
-    vcpkg_commit = '2022.08.15'
+    vcpkg_commit = '2023.02.24'
     vcpkg_url = 'https://github.com/Microsoft/vcpkg/archive/{}.zip'.format(vcpkg_commit)
     vcpkg_dir = os.path.abspath('external/vcpkg-{}'.format(vcpkg_commit))
     vcpkg_bootstrap = os.path.join(vcpkg_dir, 'bootstrap-vcpkg.bat')

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ def windows_lensfun_compile():
     dll_runtime_libs = [('lensfun.dll', os.path.join(install_dir, 'bin')),
                         ('glib-2.0-0.dll', vcpkg_bin_dir),
                         # dependencies of glib
-                        ('pcre.dll', vcpkg_bin_dir),
+                        ('pcre2-8.dll', vcpkg_bin_dir),
                         ('iconv-2.dll', vcpkg_bin_dir),
                         ('charset-1.dll', vcpkg_bin_dir),
                         ('intl-8.dll', vcpkg_bin_dir),


### PR DESCRIPTION
This pulls in changes from vcpkg 2023.02.24 (was 2022.08.15) which updates the following dependencies for Windows:

- glib 2.72.3 -> glib 2.75.3
- pcre 8.45 -> pcre2 10.40
