### PR TITLE
Change remap interpolation method to INTER_LINEAR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ How to correct lens distortion
     mod.initialize(focal_length, aperture, distance, pixel_format=img.dtype)
 
     undist_coords = mod.apply_geometry_distortion()
-    img_undistorted = cv2.remap(img, undist_coords, None, cv2.INTER_LANCZOS4)
+    img_undistorted = cv2.remap(img, undist_coords, None, cv2.INTER_LINEAR)
     cv2.imwrite(undistorted_image_path, img_undistorted)
 
 It is also possible to apply the correction via `SciPy <http://www.scipy.org>`_ instead of OpenCV.
@@ -128,9 +128,9 @@ TCA correction.
 
     # TCA Correction
     undist_coords = mod.apply_subpixel_distortion()
-    img[..., 0] = cv2.remap(img[..., 0], undist_coords[..., 0, :], None, cv2.INTER_LANCZOS4)
-    img[..., 1] = cv2.remap(img[..., 1], undist_coords[..., 1, :], None, cv2.INTER_LANCZOS4)
-    img[..., 2] = cv2.remap(img[..., 2], undist_coords[..., 2, :], None, cv2.INTER_LANCZOS4)
+    img[..., 0] = cv2.remap(img[..., 0], undist_coords[..., 0, :], None, cv2.INTER_LINEAR)
+    img[..., 1] = cv2.remap(img[..., 1], undist_coords[..., 1, :], None, cv2.INTER_LINEAR)
+    img[..., 2] = cv2.remap(img[..., 2], undist_coords[..., 2, :], None, cv2.INTER_LINEAR)
 
     imageio.imwrite('/path/to/image_corrected.tiff', img)
 


### PR DESCRIPTION
should fix rainbox aliasing artifacts when undistorting exr images with high radiance values
<img width="514" height="339" alt="image" src="https://github.com/user-attachments/assets/9c21cf9f-fef6-462e-8883-a81101dbac77" />
<img width="758" height="470" alt="image" src="https://github.com/user-attachments/assets/b4aa0128-651f-4dbc-9656-f395c9230312" />
